### PR TITLE
use filterAndPublish's argument exposeProcessInfo instead from Connections struct

### DIFF
--- a/connections/connections.go
+++ b/connections/connections.go
@@ -30,7 +30,6 @@ type FullConnection struct {
 }
 
 type Connections struct {
-	exposeProcessInfo      bool
 	listeningOn            map[incomingConnectionDedup]time.Time
 	outgoingConnectionSeen map[outgoingConnectionDedup]time.Time
 	ps                     *processes.Processes
@@ -124,7 +123,7 @@ func (c *Connections) filterAndPublish(exposeProcessInfo bool, aggregation time.
 					servers <- ServerConnection{
 						LocalIP:   localIP,
 						LocalPort: s.SrcPort,
-						Process:   process(c.ps, c.exposeProcessInfo && s.Container == nil, s.Inode),
+						Process:   process(c.ps, exposeProcessInfo && s.Container == nil, s.Inode),
 						Container: s.Container,
 					}
 				} else {


### PR DESCRIPTION
A server event contained "Process with inode ..." returned by `connections.go:108` since `exposeProcessInfo` was set to false. This was because of `connections.go:126`, in `filterAndPublish`, used `exposeProcessInfo` from Connections struct and not the supplied function argument. The struct value was not initialised and returned false.

I've removed `exposeProcessInfo` from the struct. If this is not desired, let's discuss.