### PR TITLE
Fixes #318: Do not retry containers for which gathering tcp socket information failed once

### DIFF
--- a/connections/connections.go
+++ b/connections/connections.go
@@ -45,14 +45,14 @@ func New(exposeCmdline, exposeEnviron bool) *Connections {
 }
 
 func getSocketInfoFromDocker(poller *docker.Poller, pollInterval time.Duration, socketInfo chan<- *sockets.SocketInfo) {
-  // We try to avoid leaks as in https://github.com/raboof/connbeat/issues/318 by not calling exec on failed container runs
-  var failedContainers mapset.Set = mapset.NewSet()
+	// We try to avoid leaks as in https://github.com/raboof/connbeat/issues/318 by not calling exec on failed container runs
+	var failedContainers mapset.Set = mapset.NewSet()
 
 	for {
 		logp.Info("Polling docker")
 		// For now we poll periodically
 		newFailedContainers, err := poller.PollCurrentConnections(failedContainers, socketInfo)
-    failedContainers = newFailedContainers
+		failedContainers = newFailedContainers
 		if err != nil {
 			logp.Err("Polling connections: %s", err)
 		}

--- a/connections/connections.go
+++ b/connections/connections.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/deckarep/golang-set"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/raboof/connbeat/processes"
 	"github.com/raboof/connbeat/sockets"
@@ -44,10 +45,14 @@ func New(exposeCmdline, exposeEnviron bool) *Connections {
 }
 
 func getSocketInfoFromDocker(poller *docker.Poller, pollInterval time.Duration, socketInfo chan<- *sockets.SocketInfo) {
+  // We try to avoid leaks as in https://github.com/raboof/connbeat/issues/318 by not calling exec on failed container runs
+  var failedContainers mapset.Set = mapset.NewSet()
+
 	for {
 		logp.Info("Polling docker")
 		// For now we poll periodically
-		err := poller.PollCurrentConnections(socketInfo)
+		newFailedContainers, err := poller.PollCurrentConnections(failedContainers, socketInfo)
+    failedContainers = newFailedContainers
 		if err != nil {
 			logp.Err("Polling connections: %s", err)
 		}

--- a/sockets/docker/docker.go
+++ b/sockets/docker/docker.go
@@ -84,18 +84,18 @@ func new(client *docker.Client, environment []string) (*Poller, error) {
 
 func (p *Poller) PollCurrentConnections(failedContainers mapset.Set, socketInfo chan<- *sockets.SocketInfo) (mapset.Set, error) {
 	containers, err := p.client.ListContainers(docker.ListContainersOptions{All: false})
-  currentFailedContainers := mapset.NewSet()
+	currentFailedContainers := mapset.NewSet()
 	if err != nil {
 		return currentFailedContainers, err
 	}
 	for _, container := range containers {
-    if failedContainers.Contains(container.ID) {
-      currentFailedContainers.Add(container.ID)
-      continue
-    }
+		if failedContainers.Contains(container.ID) {
+			currentFailedContainers.Add(container.ID)
+			continue
+		}
 
 		if err = p.pollCurrentConnections(container, socketInfo); err != nil {
-      currentFailedContainers.Add(container.ID)
+			currentFailedContainers.Add(container.ID)
 			logp.Warn("Failed to poll connections for container %s (%s): %s. Skipping next time to avoid resource leaks.", container.ID, container.Image, err)
 		}
 	}

--- a/sockets/docker/docker.go
+++ b/sockets/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/deckarep/golang-set"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/raboof/connbeat/sockets"
@@ -81,17 +82,24 @@ func new(client *docker.Client, environment []string) (*Poller, error) {
 	}, nil
 }
 
-func (p *Poller) PollCurrentConnections(socketInfo chan<- *sockets.SocketInfo) error {
+func (p *Poller) PollCurrentConnections(failedContainers mapset.Set, socketInfo chan<- *sockets.SocketInfo) (mapset.Set, error) {
 	containers, err := p.client.ListContainers(docker.ListContainersOptions{All: false})
+  currentFailedContainers := mapset.NewSet()
 	if err != nil {
-		return err
+		return currentFailedContainers, err
 	}
 	for _, container := range containers {
+    if failedContainers.Contains(container.ID) {
+      currentFailedContainers.Add(container.ID)
+      continue
+    }
+
 		if err = p.pollCurrentConnections(container, socketInfo); err != nil {
-			logp.Warn("Failed to poll connections for container %s (%s): %s", container.ID, container.Image, err)
+      currentFailedContainers.Add(container.ID)
+			logp.Warn("Failed to poll connections for container %s (%s): %s. Skipping next time to avoid resource leaks.", container.ID, container.Image, err)
 		}
 	}
-	return nil
+	return currentFailedContainers, nil
 }
 
 func (p *Poller) pollCurrentConnections(container docker.APIContainers, socketInfo chan<- *sockets.SocketInfo) error {
@@ -115,10 +123,9 @@ func (p *Poller) pollCurrentConnectionsFor(container docker.APIContainers, file 
 	if err != nil {
 		return err
 	}
-	var stdout, stderr bytes.Buffer
+	var stdout bytes.Buffer
 	if err = p.client.StartExec(exec.ID, docker.StartExecOptions{
 		OutputStream: &stdout,
-		ErrorStream:  &stderr,
 		RawTerminal:  false,
 	}); err != nil {
 		return err


### PR DESCRIPTION
This fixes https://github.com/raboof/connbeat/issues/318.

As a solution (workaround) to the reported issue I choose to not retry gathering tcp information on docker containers when it failed once. This circumvents the repeated leaking when exec commands fail.