### PR TITLE
tcp_diag leaks file handles #350

### DIFF
--- a/sockets/tcp_diag/tcp_diag.go
+++ b/sockets/tcp_diag/tcp_diag.go
@@ -68,6 +68,7 @@ func pollCurrentConnectionsForFamily(family uint8, socketInfo chan<- *sockets.So
 	if err != nil {
 		return err
 	}
+	defer socket.Close()
 	return pollConnections(family, socket, socketInfo)
 }
 


### PR DESCRIPTION
Close open socket for netlink

pollCurrentConnectionsForFamily creates a socket via netlink.NewNetlinkSocket
this socket is never closed and leaks. After some time the process runs out of file handles.


Fix for #350 